### PR TITLE
Update onboarding link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This is the FINN iOS Handbook, a list of documents on how we do things at FINN.
 ## Table of Contents
 
 * [Best practices](BEST_PRACTICES.md)
-* [Onboarding](ONBOARDING_PROJECT.md)
+* [Onboarding](https://github.com/finn-no/apps-handbook/blob/master/ONBOARDING_PROJECT.md)
 * [Using modern frameworks](FRAMEWORK_LINKS.md)


### PR DESCRIPTION
Noticed the onboarding link leads _nowhere_.
Guess it's supposed to lead to https://github.com/finn-no/apps-handbook/blob/master/ONBOARDING_PROJECT.md